### PR TITLE
Add shellcheck to check the portability of the shell script

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,7 +2,7 @@ name: Shellcheck
 
 on:
   push:
-    branches: [main, umireon-shellcheck]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -21,4 +21,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Shellcheck
-        run: shellcheck -s ${{ matrix.shell }}beta-install.sh
+        run: shellcheck -s ${{ matrix.shell }} beta-install.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,15 @@
+name: Shellcheck
+
+on:
+  push:
+    branches: [main, umireon-shellcheck]
+  pull_request:
+    branches: [main]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Shellcheck
+        run: shellcheck beta-install.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,7 +9,16 @@ on:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        shell:
+          - sh
+          - dash
+          - bash
+          - ksh
+
     steps:
       - uses: actions/checkout@v2
       - name: Shellcheck
-        run: shellcheck beta-install.sh
+        run: shellcheck -s {{ matrix.shell }}beta-install.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -21,4 +21,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Shellcheck
-        run: shellcheck -s {{ matrix.shell }}beta-install.sh
+        run: shellcheck -s ${{ matrix.shell }}beta-install.sh


### PR DESCRIPTION
**Please enable GitHub Actions on this repository**

[Shellcheck](https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md) is the best way to write an ultimately portable shell script as far as I know.

The example of checking is here:
https://github.com/umireon/get/runs/3353432552?check_suite_focus=true