### PR TITLE
Prefer tr and awk

### DIFF
--- a/beta-install.sh
+++ b/beta-install.sh
@@ -67,7 +67,7 @@ echo
 platform="$(detect_platform)"
 arch="$(detect_arch)"
 pkgName="@pnpm/${platform}-${arch}"
-version="$(curl -f "https://registry.npmjs.org/${pkgName}" | grep -Po '"latest":"([^"]*)' | grep -Po "[0-9].+")"
+version="$(curl -f "https://registry.npmjs.org/${pkgName}" | tr '{' '\n' | awk -F '"' '/latest/ { print $4 }')"
 archive_url="https://registry.npmjs.org/${pkgName}/-/${platform}-${arch}-${version}.tgz"
 
 curl --progress-bar --show-error --location --output "pnpm.tgz" "$archive_url"

--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ echo
 platform="$(detect_platform)"
 arch="$(detect_arch)"
 pkgName="@pnpm/${platform}-${arch}"
-version="$(curl -f "https://registry.npmjs.org/${pkgName}" | grep -Po '"latest":"([^"]*)' | grep -Po "[0-9].+")"
+version="$(curl -f "https://registry.npmjs.org/${pkgName}" | tr '{' '\n' | awk -F '"' '/latest/ { print $4 }')"
 archive_url="https://registry.npmjs.org/${pkgName}/-/${platform}-${arch}-${version}.tgz"
 
 curl --progress-bar --show-error --location --output "pnpm.tgz" "$archive_url"


### PR DESCRIPTION
`-Po` in `grep` is not defined in the POSIX standard and does not work in macOS.
`tr` and `awk` can work on macOS.

<img width="682" alt="スクリーンショット 2021-08-20 2 25 45" src="https://user-images.githubusercontent.com/1067855/130115416-82aef01b-04ed-4a8e-9a19-3573fca6e720.png">
