### PR TITLE
stop execution on error

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -17,6 +17,7 @@ jobs:
         script:
           - beta-install.sh
           - install.sh
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,6 +13,7 @@ jobs:
           - dash
           - ksh
           - sh
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,8 @@ download() {
 }
 
 detect_platform() {
-  local platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  local platform
+  platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
   case "${platform}" in
     linux) platform="linux" ;;
@@ -44,7 +45,8 @@ detect_platform() {
 }
 
 detect_arch() {
-  local arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
+  local arch
+  arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
 
   case "${arch}" in
     x86_64) arch="x64" ;;

--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ detect_arch() {
 platform="$(detect_platform)"
 arch="$(detect_arch)" || abort "Sorry! pnpm currently only provides pre-built binaries for x86_64/arm64 architectures."
 pkgName="@pnpm/${platform}-${arch}"
-version_json="$(download "httpss://registry.npmjs.org/${pkgName}")" || abort "Download Error!"
+version_json="$(download "https://registry.npmjs.org/${pkgName}")" || abort "Download Error!"
 version="$(printf '%s' "${version_json}" | tr '{' '\n' | awk -F '"' '/latest/ { print $4 }')"
 archive_url="https://registry.npmjs.org/${pkgName}/-/${platform}-${arch}-${version}.tgz"
 

--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ detect_arch() {
 platform="$(detect_platform)"
 arch="$(detect_arch)" || abort "Sorry! pnpm currently only provides pre-built binaries for x86_64/arm64 architectures."
 pkgName="@pnpm/${platform}-${arch}"
-version_json="$(download "https://registry.npmjs.org/${pkgName}")" || abort "Download Error!"
+version_json="$(download "httpss://registry.npmjs.org/${pkgName}")" || abort "Download Error!"
 version="$(printf '%s' "${version_json}" | tr '{' '\n' | awk -F '"' '/latest/ { print $4 }')"
 archive_url="https://registry.npmjs.org/${pkgName}/-/${platform}-${arch}-${version}.tgz"
 


### PR DESCRIPTION
`set -e` can be used but explicit error handling by `|| abort` is easy to maintain.